### PR TITLE
queries for articles endpoint - TASK 11

### DIFF
--- a/__tests__/endpoints.test.js
+++ b/__tests__/endpoints.test.js
@@ -230,7 +230,7 @@ describe("GET /api/articles", () => {
       });
   });
 
-  test("Status 200 - should return an array of article objects sorted in descending order by date", () => {
+  test("Status 200 - should return an array of article objects sorted in descending order by date as default", () => {
     return request(app)
       .get("/api/articles")
       .expect(200)
@@ -238,6 +238,63 @@ describe("GET /api/articles", () => {
         expect(articles).toBeSortedBy("created_at", { descending: true });
       });
   });
+
+  test("Status 200 - should return an array of article objects sorted in descending order by title when passed as a query", () => {
+    return request(app)
+      .get("/api/articles?sort_by=title")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy("title", { descending: true });
+      });
+  });
+
+  test("Status 400 - should return an error message if an invalid sort_by is passed", () => {
+    return request(app)
+      .get("/api/articles?sort_by=beans")
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe("Bad request");
+      });
+  });
+
+  test("Status 200 - should return an array of article objects sorted in ASCENDING order by date when passed as a query", () => {
+    return request(app)
+      .get("/api/articles?order=asc")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy("created_at", { ascending: true });
+      });
+  });
+
+  test("Status 400 - should return an error message if an invalid order is passed", () => {
+    return request(app)
+      .get("/api/articles?order=bea")
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe("Bad request");
+      });
+  });
+
+  //   test("Status 200 - should return an array of article objects filtered by the topic mitch when passed as a query", () => {
+  //     return request(app)
+  //       .get("/api/articles?topic=mitch")
+  //       .expect(200)
+  //       .then(({ body: { articles } }) => {
+  //         expect(articles).toBeInstanceOf(Array);
+  //         expect(articles).toHaveLength(11);
+  //         articles.forEach((article) => {
+  //           expect(article).toMatchObject({
+  //             article_id: expect.any(Number),
+  //             title: expect.any(String),
+  //             author: expect.any(String),
+  //             created_at: expect.any(String),
+  //             topic: "mitch",
+  //             votes: expect.any(Number),
+  //             comment_count: expect.any(Number),
+  //           });
+  //         });
+  //       });
+  //   });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/endpoints.test.js
+++ b/__tests__/endpoints.test.js
@@ -275,26 +275,47 @@ describe("GET /api/articles", () => {
       });
   });
 
-  //   test("Status 200 - should return an array of article objects filtered by the topic mitch when passed as a query", () => {
-  //     return request(app)
-  //       .get("/api/articles?topic=mitch")
-  //       .expect(200)
-  //       .then(({ body: { articles } }) => {
-  //         expect(articles).toBeInstanceOf(Array);
-  //         expect(articles).toHaveLength(11);
-  //         articles.forEach((article) => {
-  //           expect(article).toMatchObject({
-  //             article_id: expect.any(Number),
-  //             title: expect.any(String),
-  //             author: expect.any(String),
-  //             created_at: expect.any(String),
-  //             topic: "mitch",
-  //             votes: expect.any(Number),
-  //             comment_count: expect.any(Number),
-  //           });
-  //         });
-  //       });
-  //   });
+  test("Status 200 - should return an array of article objects filtered by the topic mitch when passed as a query", () => {
+    return request(app)
+      .get("/api/articles?topic=mitch")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeInstanceOf(Array);
+        expect(articles).toHaveLength(11);
+        articles.forEach((article) => {
+          expect(article).toMatchObject({
+            article_id: expect.any(Number),
+            title: expect.any(String),
+            author: expect.any(String),
+            created_at: expect.any(String),
+            topic: "mitch",
+            votes: expect.any(Number),
+            comment_count: expect.any(Number),
+          });
+        });
+      });
+  });
+
+  test("Status 200 - should return an array of article objects filtered by the topic cats when passed as a query", () => {
+    return request(app)
+      .get("/api/articles?topic=cats")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeInstanceOf(Array);
+        expect(articles).toHaveLength(1);
+        articles.forEach((article) => {
+          expect(article).toMatchObject({
+            article_id: expect.any(Number),
+            title: expect.any(String),
+            author: expect.any(String),
+            created_at: expect.any(String),
+            topic: "cats",
+            votes: expect.any(Number),
+            comment_count: expect.any(Number),
+          });
+        });
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/controllers/articlesControllers.js
+++ b/controllers/articlesControllers.js
@@ -30,7 +30,10 @@ exports.updateArticleVotes = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  fetchArticlesFromDb()
+  const { sort_by, order, topic } = req.query;
+  console.log(topic)
+
+  fetchArticlesFromDb(sort_by, order, topic)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/controllers/articlesControllers.js
+++ b/controllers/articlesControllers.js
@@ -31,7 +31,6 @@ exports.updateArticleVotes = (req, res, next) => {
 
 exports.getArticles = (req, res, next) => {
   const { sort_by, order, topic } = req.query;
-  console.log(topic)
 
   fetchArticlesFromDb(sort_by, order, topic)
     .then((articles) => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,8 +10,23 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all topics",
+    "description": "serves an array of all articles",
     "queries": ["author", "topic", "sort_by", "order"],
+    "exampleResponse": {
+      "articles": [
+        {
+          "title": "Seafood substitutions are increasing",
+          "topic": "cooking",
+          "author": "weegembump",
+          "body": "Text from the article..",
+          "created_at": 1527695953341
+        }
+      ]
+    }
+  },
+  "GET /api/articles/:article_id": {
+    "description": "serves an object of the required article",
+    "queries": [],
     "exampleResponse": {
       "articles": [
         {

--- a/models/articlesModels.js
+++ b/models/articlesModels.js
@@ -47,8 +47,15 @@ exports.updateArticleVotesInDb = (id, inc_votes) => {
   });
 };
 
-exports.fetchArticlesFromDb = () => {
-  const queryStr = `
+exports.fetchArticlesFromDb = (
+  sort_by = "created_at",
+  order = "desc",
+  topic
+) => {
+  const validSortBy = ["created_at", "title", "author", "votes"];
+  const validOrder = ["ASC", "DESC"];
+
+  let queryStr = `
         SELECT 
         articles.article_id,
         title,
@@ -61,8 +68,18 @@ exports.fetchArticlesFromDb = () => {
         LEFT JOIN comments
         ON comments.article_id = articles.article_id
         GROUP BY articles.article_id
-        ORDER BY articles.created_at DESC
-    `;
+      `;
+
+  if (order) {
+    order = order.toUpperCase();
+  }
+
+  if (!validSortBy.includes(sort_by) || !validOrder.includes(order)) {
+    return Promise.reject({ status: 400, msg: "Bad request" });
+  } else {
+    queryStr += `ORDER BY articles.${sort_by} ${order}`;
+  }
+
   return db.query(queryStr).then((data) => {
     return data.rows.map((article) => {
       return {

--- a/models/articlesModels.js
+++ b/models/articlesModels.js
@@ -67,8 +67,13 @@ exports.fetchArticlesFromDb = (
         FROM articles
         LEFT JOIN comments
         ON comments.article_id = articles.article_id
-        GROUP BY articles.article_id
       `;
+
+  if (topic) {
+    queryStr += `WHERE topic LIKE '${topic}'`;
+  }
+
+  queryStr += ` GROUP BY articles.article_id`;
 
   if (order) {
     order = order.toUpperCase();
@@ -77,7 +82,7 @@ exports.fetchArticlesFromDb = (
   if (!validSortBy.includes(sort_by) || !validOrder.includes(order)) {
     return Promise.reject({ status: 400, msg: "Bad request" });
   } else {
-    queryStr += `ORDER BY articles.${sort_by} ${order}`;
+    queryStr += ` ORDER BY articles.${sort_by} ${order}`;
   }
 
   return db.query(queryStr).then((data) => {

--- a/models/articlesModels.js
+++ b/models/articlesModels.js
@@ -54,6 +54,7 @@ exports.fetchArticlesFromDb = (
 ) => {
   const validSortBy = ["created_at", "title", "author", "votes"];
   const validOrder = ["ASC", "DESC"];
+  const queryParams = [];
 
   let queryStr = `
         SELECT 
@@ -70,7 +71,8 @@ exports.fetchArticlesFromDb = (
       `;
 
   if (topic) {
-    queryStr += `WHERE topic LIKE '${topic}'`;
+    queryStr += `WHERE topic LIKE $1`;
+    queryParams.push(topic);
   }
 
   queryStr += ` GROUP BY articles.article_id`;
@@ -85,7 +87,7 @@ exports.fetchArticlesFromDb = (
     queryStr += ` ORDER BY articles.${sort_by} ${order}`;
   }
 
-  return db.query(queryStr).then((data) => {
+  return db.query(queryStr, queryParams).then((data) => {
     return data.rows.map((article) => {
       return {
         ...article,

--- a/models/commentsModels.js
+++ b/models/commentsModels.js
@@ -29,7 +29,6 @@ exports.addNewCommentToDbByArticleId = (id, newComment) => {
   `;
 
   return db.query(queryStr, [body, id, username, 0]).then((data) => {
-    console.log(data.rows[0]);
     return data.rows[0];
   });
 };


### PR DESCRIPTION
- sort_by now available with restrictions
- order now available with restrictions
- articles can now be filtered by topic
- 400 errors tested for a variety of bad requests
- edit to endpoints.json to be ignored (was working on wrong branch)